### PR TITLE
feat: make topic_policy_statements optional

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,5 +1,5 @@
 ## Reporting a Vulnerability
 
 If you discover a potential security issue in this project please notify me via email to `security@justtrack.io`.
- 
+
 Please do **not** create a public github issue.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Terraform module which creates a sns topic
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sns"></a> [sns](#module\_sns) | terraform-aws-modules/sns/aws | 5.3.0 |
+| <a name="module_sns"></a> [sns](#module\_sns) | terraform-aws-modules/sns/aws | 6.1.0 |
 | <a name="module_sns_label"></a> [sns\_label](#module\_sns\_label) | justtrackio/label/null | 0.26.0 |
 | <a name="module_this"></a> [this](#module\_this) | justtrackio/label/null | 0.26.0 |
 
@@ -55,7 +55,7 @@ Terraform module which creates a sns topic
 | <a name="input_organizational_unit"></a> [organizational\_unit](#input\_organizational\_unit) | Usually used to indicate the AWS organizational unit, e.g. 'prod', 'sdlc' | `string` | `null` | no |
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br>Characters matching the regex will be removed from the ID elements.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
-| <a name="input_subscription_aws_account_id"></a> [subscription\_aws\_account\_id](#input\_subscription\_aws\_account\_id) | The AWS account ID for the subscription. | `string` | n/a | yes |
+| <a name="input_subscription_aws_account_id"></a> [subscription\_aws\_account\_id](#input\_subscription\_aws\_account\_id) | The AWS account ID for the subscription. | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |
 

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,18 @@
+locals {
+  topic_policy_statements = var.subscription_aws_account_id != null ? {
+    subscription = {
+      actions = ["sns:Subscribe"]
+
+      principals = [
+        {
+          type        = "AWS"
+          identifiers = [var.subscription_aws_account_id]
+        }
+      ]
+    }
+  } : {}
+}
+
 module "sns_label" {
   source  = "justtrackio/label/null"
   version = "0.26.0"
@@ -9,21 +24,10 @@ module "sns_label" {
 
 module "sns" {
   source  = "terraform-aws-modules/sns/aws"
-  version = "5.3.0"
+  version = "6.1.0"
 
   name = module.sns_label.id
   tags = module.sns_label.tags
 
-  topic_policy_statements = {
-    subscription = {
-      actions = ["sns:Subscribe"]
-
-      principals = [
-        {
-          type        = "AWS"
-          identifiers = [var.subscription_aws_account_id]
-        }
-      ]
-    }
-  }
+  topic_policy_statements = local.topic_policy_statements
 }

--- a/variables.tf
+++ b/variables.tf
@@ -24,5 +24,6 @@ variable "alarm_topic_arn" {
 
 variable "subscription_aws_account_id" {
   type        = string
+  default     = null
   description = "The AWS account ID for the subscription."
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
